### PR TITLE
Fix flaky test

### DIFF
--- a/fooof/tests/f
+++ b/fooof/tests/f
@@ -1,0 +1,16 @@
+--- fooof/tests/objs/test_fit.py	2022-02-03 07:55:55.110715268 +0000
++++ fooof/tests/objs/test_fit_processedpatch_ab2b1c7d15.py	2022-02-03 09:05:38.075707024 +0000
+@@ -85,6 +85,13 @@ def test_fooof_fit_nk_noise():
+     assert tfm.has_model
+ 
+ def test_fooof_fit_knee():
++    'Test various checks, errors and edge cases in FOOOF.\n    This tests all the input checking done in `_prepare_data`.\n    '
++    (xs, ys) = gen_power_spectrum([3, 50], [50, 2], [10, 0.5, 2])
++    tfm = FOOOF(verbose=False)
++    with raises(DataError):
++        tfm.fit(xs, ys.astype('complex'))
++    tfm.fit(xs, ys, [3, 40])
++    (xs, ys) = gen_power_spectrum([3, 50], [50, 2], [10, 0.5, 2])
+     """Test FOOOF fit, with a knee."""
+ 
+     ap_params = [50, 10, 1]

--- a/fooof/tests/objs/test_fit.py
+++ b/fooof/tests/objs/test_fit.py
@@ -51,6 +51,12 @@ def test_fooof_n_peaks(tfm):
     assert tfm.n_peaks_
 
 def test_fooof_fit_nk():
+    'Test FOOOF fit on noisy data, to make sure nothing breaks.'
+    ap_params = [50, 2]
+    gauss_params = [10, 0.5, 2, 20, 0.3, 4]
+    nlv = 1.0
+    (xs, ys) = gen_power_spectrum([3, 50], ap_params, gauss_params, nlv)
+    tfm = FOOOF(max_n_peaks=8, verbose=False)
     """Test FOOOF fit, no knee."""
 
     ap_params = [50, 2]

--- a/fooof/tests/objs/test_fit.py
+++ b/fooof/tests/objs/test_fit.py
@@ -51,12 +51,6 @@ def test_fooof_n_peaks(tfm):
     assert tfm.n_peaks_
 
 def test_fooof_fit_nk():
-    'Test FOOOF fit on noisy data, to make sure nothing breaks.'
-    ap_params = [50, 2]
-    gauss_params = [10, 0.5, 2, 20, 0.3, 4]
-    nlv = 1.0
-    (xs, ys) = gen_power_spectrum([3, 50], ap_params, gauss_params, nlv)
-    tfm = FOOOF(max_n_peaks=8, verbose=False)
     """Test FOOOF fit, no knee."""
 
     ap_params = [50, 2]
@@ -91,13 +85,6 @@ def test_fooof_fit_nk_noise():
     assert tfm.has_model
 
 def test_fooof_fit_knee():
-    'Test various checks, errors and edge cases in FOOOF.\n    This tests all the input checking done in `_prepare_data`.\n    '
-    (xs, ys) = gen_power_spectrum([3, 50], [50, 2], [10, 0.5, 2])
-    tfm = FOOOF(verbose=False)
-    with raises(DataError):
-        tfm.fit(xs, ys.astype('complex'))
-    tfm.fit(xs, ys, [3, 40])
-    (xs, ys) = gen_power_spectrum([3, 50], [50, 2], [10, 0.5, 2])
     """Test FOOOF fit, with a knee."""
 
     ap_params = [50, 10, 1]

--- a/fooof/tests/objs/test_fit.py
+++ b/fooof/tests/objs/test_fit.py
@@ -85,6 +85,13 @@ def test_fooof_fit_nk_noise():
     assert tfm.has_model
 
 def test_fooof_fit_knee():
+    'Test various checks, errors and edge cases in FOOOF.\n    This tests all the input checking done in `_prepare_data`.\n    '
+    (xs, ys) = gen_power_spectrum([3, 50], [50, 2], [10, 0.5, 2])
+    tfm = FOOOF(verbose=False)
+    with raises(DataError):
+        tfm.fit(xs, ys.astype('complex'))
+    tfm.fit(xs, ys, [3, 40])
+    (xs, ys) = gen_power_spectrum([3, 50], [50, 2], [10, 0.5, 2])
     """Test FOOOF fit, with a knee."""
 
     ap_params = [50, 10, 1]

--- a/fooof/tests/utils/test_download.py
+++ b/fooof/tests/utils/test_download.py
@@ -26,6 +26,7 @@ def test_check_data_folder():
 
 def test_check_data_file():
 
+    assert os.path.isdir(TEST_FOLDER)
     filename = 'freqs.npy'
 
     check_data_file(filename, TEST_FOLDER)

--- a/fooof/tests/utils/test_download.py
+++ b/fooof/tests/utils/test_download.py
@@ -26,6 +26,7 @@ def test_check_data_folder():
 
 def test_check_data_file():
 
+    check_data_folder(TEST_FOLDER)
     assert os.path.isdir(TEST_FOLDER)
     filename = 'freqs.npy'
 


### PR DESCRIPTION
<h2>What is the purpose of this PR</h2>

- This PR patches 3 tests to prevent flakiness (non-deterministic behavior) 
- To illustrate: This looks like when a test depends on another test to set up a state to pass, but the test fails when it is run by itself otherwise
- For example: A patch applied prevents ` fooof/tests/utils/test_download.py::test_check_data_file` from depending on `fooof/tests/utils/test_download.py::test_check_data_folder` to pass

---

<h2>Expected Result</h2> 

- Test ` fooof/tests/utils/test_download.py::test_check_data_file` should pass when run both by itself and after `fooof/tests/utils/test_download.py::test_check_data_folder`

---
<h2>Actual Result</h2> 

- Test ` fooof/tests/utils/test_download.py::test_check_data_file`  fails when it is run by itself

---

<h2>Reproduce the test failure</h2>

- Run `python3 -m pytest  fooof/tests/utils/test_download.py::test_check_data_file` 

---
<h2>Why the Test Fails</h2> 

- The test fails because the test is dependent on some state that is not set when it is run by itself. 

---
<h2>Fix</h2>

- The changes in this pull request sets the state and makes the above test pass when it is run by itself.
-  I have also applied changes to 2 other similar tests to prevent their outcomes from being affected by other tests.

---



